### PR TITLE
Update listener.yml

### DIFF
--- a/src/Resources/config/listener.yml
+++ b/src/Resources/config/listener.yml
@@ -3,3 +3,4 @@ services:
       class: HeimrichHannot\SpeedBundle\EventListener\HookListener
       arguments:
         - "@contao.framework"
+      public: true


### PR DESCRIPTION
Hook listener services must be defined as "public" in contao 4.6.x.